### PR TITLE
Fix build failure from orphaned ProductDetailView fragment

### DIFF
--- a/grain/Views/ProductsView.swift
+++ b/grain/Views/ProductsView.swift
@@ -137,20 +137,6 @@ struct ProductsView: View {
         }
     }
 
-struct ProductDetailView: View {
-    let product: Product
-    
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                productHeader
-                
-                if !product.priceHistory.isEmpty {
-                    priceHistorySection
-                }
-                
-                if let description = product.productDescription {
-                    descriptionSection(description)
     // MARK: - Brands (cards)
 
     private var brandsSubview: some View {


### PR DESCRIPTION
## Summary
- Removed an incomplete `ProductDetailView` struct that was accidentally left inside `ProductsView`'s scope after a merge
- This orphaned fragment caused 12 compiler errors (`private` in non-local scope + missing braces)

## Test plan
- [x] Project builds successfully after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)