### PR TITLE
README: replace screenshot tiles with FLOW/FEATURES/STATS/NOTES dashboard + ASCII docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,40 +44,85 @@ iOS&thinsp;17+ · local-only<br />
 
 <td width="44%">
 
-<table align="center">
-<tr><td colspan="2" bgcolor="000000" align="center"><b><samp><font color="white">S&thinsp;C&thinsp;R&thinsp;E&thinsp;E&thinsp;N&thinsp;S</font></samp></b></td></tr>
+<table width="100%">
+
+<tr><td colspan="2" bgcolor="000000" align="center"><b><samp><font color="white">F&thinsp;L&thinsp;O&thinsp;W</font></samp></b></td></tr>
+<tr><td colspan="2" align="center"><br /><samp><font color="888888">scan&thinsp;→&thinsp;ocr&thinsp;→&thinsp;parse&thinsp;→&thinsp;save&thinsp;→&thinsp;browse&thinsp;→&thinsp;analyze</font></samp><br /><br /></td></tr>
+
+<tr><td colspan="2" bgcolor="000000" align="center"><b><samp><font color="white">F&thinsp;E&thinsp;A&thinsp;T&thinsp;U&thinsp;R&thinsp;E&thinsp;S</font></samp></b></td></tr>
+
 <tr>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/03-scan.png" width="180" alt="scan" /><br /><sup>scan</sup></a>
+<td bgcolor="0d0d0d" width="50%" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">scan</font></samp></td></tr></table>
+<sup><font color="888888">camera · viewfinder · ocr</font></sup><br />
+<a href="#what-it-does"><sup>→ what it does</sup></a>&ensp;<sup><font color="44aa66">✓</font></sup>
 </td>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/04-proof.png" width="180" alt="proof" /><br /><sup>proof</sup></a>
+<td bgcolor="0d0d0d" width="50%" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">receipts</font></samp></td></tr></table>
+<sup><font color="888888">list · detail · swipe</font></sup><br />
+<a href="#what-it-does"><sup>→ what it does</sup></a>&ensp;<sup><font color="44aa66">✓</font></sup>
+</td>
+</tr>
+
+<tr>
+<td bgcolor="0d0d0d" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">analytics</font></samp></td></tr></table>
+<sup><font color="888888">category · brand · merchant</font></sup><br />
+<a href="#what-it-does"><sup>→ what it does</sup></a>&ensp;<sup><font color="44aa66">✓</font></sup>
+</td>
+<td bgcolor="0d0d0d" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">price watch</font></samp></td></tr></table>
+<sup><font color="888888">item · history · trend</font></sup><br />
+<a href="#what-it-does"><sup>→ what it does</sup></a>&ensp;<sup><font color="44aa66">✓</font></sup>
+</td>
+</tr>
+
+<tr>
+<td bgcolor="0d0d0d" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">index</font></samp></td></tr></table>
+<sup><font color="888888">products · brands · retailers</font></sup><br />
+<a href="#what-it-does"><sup>→ what it does</sup></a>&ensp;<sup><font color="44aa66">✓</font></sup>
+</td>
+<td bgcolor="0d0d0d" valign="top">
+<table width="100%"><tr><td bgcolor="1c1c1c"><samp><font color="white">manual entry</font></samp></td></tr></table>
+<sup><font color="888888">fallback · no camera</font></sup><br />
+<a href="docs/Current-State.md"><sup>→ current state</sup></a>&ensp;<sup><font color="aa5533">○ todo</font></sup>
+</td>
+</tr>
+
+<tr><td colspan="2" bgcolor="000000" align="center"><b><samp><font color="white">S&thinsp;T&thinsp;A&thinsp;T&thinsp;S</font></samp></b></td></tr>
+<tr><td colspan="2" align="center"><br />
+<table align="center"><tr>
+<td bgcolor="0d0d0d" align="center">&thinsp;<b><samp><font color="white">5</font></samp></b>&thinsp;<sup><font color="666666">tabs</font></sup>&thinsp;</td>
+<td bgcolor="0d0d0d" align="center">&thinsp;<b><samp><font color="white">7</font></samp></b>&thinsp;<sup><font color="666666">models</font></sup>&thinsp;</td>
+<td bgcolor="0d0d0d" align="center">&thinsp;<b><samp><font color="white">5</font></samp></b>&thinsp;<sup><font color="666666">ADRs</font></sup>&thinsp;</td>
+<td bgcolor="0d0d0d" align="center">&thinsp;<b><samp><font color="white">20</font></samp></b>&thinsp;<sup><font color="666666">files</font></sup>&thinsp;</td>
+</tr></table>
+<br /></td></tr>
+
+<tr><td colspan="2" bgcolor="000000" align="center"><b><samp><font color="white">N&thinsp;O&thinsp;T&thinsp;E&thinsp;S</font></samp></b></td></tr>
+
+<tr>
+<td bgcolor="0d0d0d" valign="top">
+<samp><font color="555555">→&thinsp;</font></samp><a href="docs/Current-State.md"><samp>mvp delta</samp></a><br />
+<sup><font color="555555">parser · errors · images · edit</font></sup>
+</td>
+<td bgcolor="0d0d0d" valign="top">
+<samp><font color="555555">→&thinsp;</font></samp><a href="docs/adr/README.md#index"><samp>arch decisions</samp></a><br />
+<sup><font color="555555">5 adrs · zero deps · local-only</font></sup>
 </td>
 </tr>
 <tr>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/01-home.png" width="180" alt="receipts" /><br /><sup>receipts</sup></a>
+<td bgcolor="0d0d0d" valign="top">
+<samp><font color="555555">→&thinsp;</font></samp><a href="CHANGELOG.md"><samp>changelog</samp></a><br />
+<sup><font color="555555">v0.1.0 · poc · notifications</font></sup>
 </td>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/02-detail.png" width="180" alt="detail" /><br /><sup>detail</sup></a>
-</td>
-</tr>
-<tr>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/05-analytics.png" width="180" alt="analytics" /><br /><sup>analytics</sup></a>
-</td>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/06-itemwatch.png" width="180" alt="item watch" /><br /><sup>item watch</sup></a>
+<td bgcolor="0d0d0d" valign="top">
+<samp><font color="555555">→&thinsp;</font></samp><a href="docs/Redesign-Spec.md"><samp>redesign spec</samp></a><br />
+<sup><font color="555555">typography · tokens · wireframes</font></sup>
 </td>
 </tr>
-<tr>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/07-index.png" width="180" alt="index" /><br /><sup>index</sup></a>
-</td>
-<td align="center">
-<a href="#what-it-does"><img src=".github/assets/tiles/08-retailers.png" width="180" alt="retailers" /><br /><sup>retailers</sup></a>
-</td>
-</tr>
+
 </table>
 
 </td>

--- a/docs/Current-State.md
+++ b/docs/Current-State.md
@@ -2,6 +2,24 @@
 
 Audited on 2026-04-01 against local branch main.
 
+```
+┌──────────────────────────────────────────────────────────────┐
+│  grain · current state · 2026-04-01                         │
+│  ──────────────────────────────────────────────────────────  │
+│  ✓  scan → ocr → parse → save                              │
+│  ✓  receipt list + detail view                             │
+│  ✓  analytics: category · brand · merchant                 │
+│  ✓  product index + brand catalog                          │
+│  ✓  ci: build + test on every pr                           │
+│  ──────────────────────────────────────────────────────────  │
+│  ✗  receipt image not persisted                            │
+│  ✗  edit from scan proof (todo button)                     │
+│  ✗  manual entry fallback (todo button)                    │
+│  ○  bank transaction import (model exists, no ui)          │
+│  ○  user-facing error states (silent print)                │
+└──────────────────────────────────────────────────────────────┘
+```
+
 ## Executive Snapshot
 
 Grain has a healthy proof-of-concept core: scan receipts, parse text, store receipts, browse details, and view analytics.
@@ -67,6 +85,23 @@ The main project risk is not architecture. The main risk is product completeness
 - MVP definition needs explicit acceptance criteria so feature work does not sprawl.
 
 ## Priority Workstream Recommendation
+
+```
+  ╔══════════════════════════════════════════╗
+  ║  MVP PRIORITY LADDER                     ║
+  ╠══════════════════════════════════════════╣
+  ║  1  backlog hygiene     close stale issues ║
+  ║  2  manual entry        biggest ux gap   ║
+  ║  3  scan proof edit     wire todo button ║
+  ║  4  image persistence   wire imageData   ║
+  ╠══════════════════════════════════════════╣
+  ║  5  parser reliability  test corpus      ║
+  ║  6  error ux            replace print()  ║
+  ╠══════════════════════════════════════════╣
+  ║  ✗  cloud sync          deferred (adr-0005) ║
+  ║  ✗  backend api         deferred         ║
+  ╚══════════════════════════════════════════╝
+```
 
 1. Stabilize backlog hygiene:
 - Close completed and out-of-scope issues.


### PR DESCRIPTION
## Summary

- Replaces the 2×4 screenshot tile grid with a richer center column that works without images
- Adds ASCII box-drawing visuals to `docs/Current-State.md`

## Dashboard center column

| Section | Approach | Content |
|---------|----------|---------|
| `FLOW` | Flow strip (C) | `scan → ocr → parse → save → browse → analyze` |
| `FEATURES` | Hybrid cards (F) | 6 cards with mini-header, keywords, link, ✓/○ status |
| `STATS` | Metric chips (E) | `5 tabs · 7 models · 5 ADRs · 20 files` |
| `NOTES` | Linked tiles (D) | mvp delta, arch decisions, changelog, redesign spec |

## Docs

`docs/Current-State.md` gains:
- Status board (✓/✗/○ for every capability)
- Priority ladder (╔═╗ box with numbered tiers)

## Test plan

- [ ] README 3-column layout renders correctly on GitHub
- [ ] All nav links and note tile links resolve
- [ ] ASCII blocks in docs render correctly
- [ ] No broken image references

🤖 Generated with [Claude Code](https://claude.com/claude-code)